### PR TITLE
update stats chart to match figma

### DIFF
--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -16,6 +16,7 @@ import {
   UseInterceptors,
   Req,
   UnauthorizedException,
+  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -316,6 +317,20 @@ export class DonationsController {
     type: Number,
     description: 'maximum donation amount',
   })
+  @ApiQuery({
+    name: 'startDate',
+    required: false,
+    type: String,
+    description: 'filter by start date (YYYY-MM-DD format)',
+    example: '2026-01-01',
+  })
+  @ApiQuery({
+    name: 'endDate',
+    required: false,
+    type: String,
+    description: 'filter by end date (YYYY-MM-DD format)',
+    example: '2026-12-31',
+  })
   @ApiResponse({
     status: 200,
     description: 'paginated donation list',
@@ -351,6 +366,8 @@ export class DonationsController {
     minAmount?: number,
     @Query('maxAmount', new ParseIntPipe({ optional: true }))
     maxAmount?: number,
+    @Query('startDate') startDateStr?: string,
+    @Query('endDate') endDateStr?: string,
   ): Promise<{
     rows: DonationResponseDto[];
     total: number;
@@ -365,6 +382,28 @@ export class DonationsController {
       throw new UnauthorizedException('Admin access required');
     }
 
+    // Parse date strings to Date objects
+    let startDate: Date | undefined;
+    let endDate: Date | undefined;
+
+    if (startDateStr) {
+      startDate = new Date(startDateStr);
+      if (isNaN(startDate.getTime())) {
+        throw new BadRequestException(
+          'Invalid startDate format. Use YYYY-MM-DD',
+        );
+      }
+    }
+
+    if (endDateStr) {
+      endDate = new Date(endDateStr);
+      // Add one day to endDate to include the entire end date
+      endDate.setDate(endDate.getDate() + 1);
+      if (isNaN(endDate.getTime())) {
+        throw new BadRequestException('Invalid endDate format. Use YYYY-MM-DD');
+      }
+    }
+
     const filters: PaginationFilters = {
       donationType,
       status,
@@ -372,6 +411,8 @@ export class DonationsController {
       recurringInterval,
       minAmount,
       maxAmount,
+      startDate,
+      endDate,
     };
 
     const result = await this.donationsRepository.findPaginated(

--- a/apps/backend/src/donations/donations.controller.ts
+++ b/apps/backend/src/donations/donations.controller.ts
@@ -382,7 +382,6 @@ export class DonationsController {
       throw new UnauthorizedException('Admin access required');
     }
 
-    // Parse date strings to Date objects
     let startDate: Date | undefined;
     let endDate: Date | undefined;
 

--- a/apps/frontend/src/api/apiClient.ts
+++ b/apps/frontend/src/api/apiClient.ts
@@ -127,7 +127,7 @@ export class ApiClient {
       this.handleAxiosError(err, 'Failed to reset password');
     }
   }
-  
+
   public async getActiveGoalSummary(): Promise<ActiveGoalResponse> {
     try {
       const res = await this.axiosInstance.get('/api/donations/goal/active');
@@ -183,6 +183,8 @@ export class ApiClient {
     perPage?: number;
     donationType?: 'one_time' | 'recurring';
     status?: 'pending' | 'succeeded' | 'failed' | 'cancelled';
+    startDate?: string;
+    endDate?: string;
   }): Promise<{
     rows: Array<{
       id: number;

--- a/apps/frontend/src/components/DonorStatsChart.tsx
+++ b/apps/frontend/src/components/DonorStatsChart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts';
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 
 import {
   Card,
@@ -15,48 +15,80 @@ import {
   type ChartConfig,
 } from '@components/ui/chart';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@components/ui/dropdown-menu';
-import { Input } from '@components/ui/input';
-import { Label } from '@components/ui/label';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@components/ui/popover';
 import { ChevronDownIcon } from 'lucide-react';
+import { YearMonthPickerPanel, type YearMonthValue } from './YearMonthPicker';
 import apiClient from '@api/apiClient';
 
 const chartConfig = {
   donations: {
     label: 'Total Donations',
-    color: 'hsl(160, 60%, 45%)',
+    color: 'rgba(42, 157, 144, 0.7)',
   },
-  recurring_donors: {
-    label: 'Recurring Donors',
-    color: 'hsl(220, 70%, 50%)',
+  recurring_donations: {
+    label: 'Recurring Donations',
+    color: 'rgb(215, 209, 117)',
   },
 } satisfies ChartConfig;
 
-type DataType = 'donations' | 'recurring_donors';
-type TimeUnit = 'weeks' | 'months' | 'years';
+type DataType = 'donations' | 'recurring_donations';
+type TimeframeType = 'year-to-date' | 'custom';
 
 // Helper function to calculate date range
-function getStartDate(quantity: number, unit: TimeUnit): Date {
+function getStartDate(
+  timeframeType: TimeframeType,
+  customPeriod?: YearMonthValue,
+): Date {
   const now = new Date();
-  const start = new Date(now);
 
-  switch (unit) {
-    case 'weeks':
-      start.setDate(now.getDate() - quantity * 7);
-      break;
-    case 'months':
-      start.setMonth(now.getMonth() - quantity);
-      break;
-    case 'years':
-      start.setFullYear(now.getFullYear() - quantity);
-      break;
+  if (timeframeType === 'year-to-date') {
+    // Start from Jan 1 of current year
+    return new Date(now.getFullYear(), 0, 1);
   }
 
-  return start;
+  // Custom period
+  if (!customPeriod) {
+    // If no custom period yet, use today
+    return now;
+  }
+
+  if (customPeriod.month === null) {
+    // Year only - start from Jan 1 of that year
+    return new Date(customPeriod.year, 0, 1);
+  }
+
+  // Year and month - start from 1st of that month (1-indexed)
+  return new Date(customPeriod.year, customPeriod.month - 1, 1);
+}
+
+// Helper function to calculate end date
+function getEndDate(
+  timeframeType: TimeframeType,
+  customPeriod?: YearMonthValue,
+): Date {
+  const now = new Date();
+
+  if (timeframeType === 'year-to-date') {
+    // End is today
+    return now;
+  }
+
+  // Custom period
+  if (!customPeriod) {
+    // If no custom period yet, use today
+    return now;
+  }
+
+  if (customPeriod.month === null) {
+    // Year only - end at Jan 1 of next year
+    return new Date(customPeriod.year + 1, 0, 1);
+  }
+
+  // Year and month - end at 1st of next month
+  return new Date(customPeriod.year, customPeriod.month, 1);
 }
 
 // Helper function to format date as YYYY-MM-DD in local time
@@ -82,13 +114,34 @@ function parseDateKey(value: string): Date {
 // Process donations data into time-series
 function processDonationsData(
   donations: Array<{ amount: number; createdAt: string; status: string }>,
-  startDate: Date,
 ): Array<{ date: string; value: number }> {
   const dataMap = new Map<string, number>();
 
   donations.forEach((donation) => {
     const donationDate = parseBackendDate(donation.createdAt);
-    if (donationDate >= startDate && donation.status === 'succeeded') {
+    const dateKey = formatDate(donationDate);
+    dataMap.set(dateKey, (dataMap.get(dateKey) || 0) + donation.amount);
+  });
+
+  return Array.from(dataMap.entries())
+    .map(([date, value]) => ({ date, value }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// Process recurring donations data (recurring donations only)
+function processRecurringDonationsData(
+  donations: Array<{
+    amount: number;
+    createdAt: string;
+    donationType: string;
+    status: string;
+  }>,
+): Array<{ date: string; value: number }> {
+  const dataMap = new Map<string, number>();
+
+  donations.forEach((donation) => {
+    if (donation.donationType === 'recurring') {
+      const donationDate = parseBackendDate(donation.createdAt);
       const dateKey = formatDate(donationDate);
       dataMap.set(dateKey, (dataMap.get(dateKey) || 0) + donation.amount);
     }
@@ -99,166 +152,118 @@ function processDonationsData(
     .sort((a, b) => a.date.localeCompare(b.date));
 }
 
-// Process recurring donors data (first recurring donation per email)
-function processRecurringDonorsData(
-  donations: Array<{
-    email: string;
-    createdAt: string;
-    donationType: string;
-    status: string;
-  }>,
-  startDate: Date,
-): Array<{ date: string; value: number }> {
-  // Find first recurring donation per email
-  const firstRecurringByEmail = new Map<string, Date>();
-
-  donations.forEach((donation) => {
-    if (
-      donation.donationType === 'recurring' &&
-      donation.status === 'succeeded'
-    ) {
-      const donationDate = parseBackendDate(donation.createdAt);
-      const existing = firstRecurringByEmail.get(donation.email);
-
-      if (!existing || donationDate < existing) {
-        firstRecurringByEmail.set(donation.email, donationDate);
-      }
-    }
-  });
-
-  // Group by date
-  const dataMap = new Map<string, number>();
-
-  firstRecurringByEmail.forEach((firstDate) => {
-    if (firstDate >= startDate) {
-      const dateKey = formatDate(firstDate);
-      dataMap.set(dateKey, (dataMap.get(dateKey) || 0) + 1);
-    }
-  });
-
-  return Array.from(dataMap.entries())
-    .map(([date, value]) => ({ date, value }))
-    .sort((a, b) => a.date.localeCompare(b.date));
-}
-
 export function DonorStatsChart() {
   const [activeChart, setActiveChart] = React.useState<DataType>('donations');
-  const [quantity, setQuantity] = React.useState<number>(6);
-  const [unit, setUnit] = React.useState<TimeUnit>('months');
+  const [timeframeType, setTimeframeType] =
+    React.useState<TimeframeType>('year-to-date');
+  const [customPeriod, setCustomPeriod] = React.useState<YearMonthValue>();
   const [chartData, setChartData] = React.useState<
     Array<{ date: string; value: number }>
   >([]);
   const [donationsData, setDonationsData] = React.useState<
     Array<{ date: string; value: number }>
   >([]);
-  const [recurringDonorsData, setRecurringDonorsData] = React.useState<
+  const [recurringDonationsData, setRecurringDonationsData] = React.useState<
     Array<{ date: string; value: number }>
   >([]);
-  const [isLoading, setIsLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [customPickerOpen, setCustomPickerOpen] = React.useState(false);
 
-  // Fetch data whenever quantity or unit changes
+  // Fetch data whenever timeframeType or customPeriod changes
   React.useEffect(() => {
     const fetchData = async () => {
-      setIsLoading(true);
       setError(null);
       try {
-        // Fetch donations with a large perPage to get all we need
+        const startDate = getStartDate(timeframeType, customPeriod);
+        const endDate = getEndDate(timeframeType, customPeriod);
+
+        // Format dates as YYYY-MM-DD for API
+        const startDateStr = formatDate(startDate);
+        const endDateStr = formatDate(endDate);
+
+        // Fetch donations with date range filter
         const response = await apiClient.getDonations({
           perPage: 10000,
           status: 'succeeded',
+          startDate: startDateStr,
+          endDate: endDateStr,
         });
 
-        const startDate = getStartDate(quantity, unit);
-        const donationsProcessed = processDonationsData(
+        const donationsProcessed = processDonationsData(response.rows);
+        const recurringDonationsProcessed = processRecurringDonationsData(
           response.rows,
-          startDate,
-        );
-        const recurringDonorsProcessed = processRecurringDonorsData(
-          response.rows,
-          startDate,
         );
 
         setDonationsData(donationsProcessed);
-        setRecurringDonorsData(recurringDonorsProcessed);
+        setRecurringDonationsData(recurringDonationsProcessed);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load data');
         setChartData([]);
-      } finally {
-        setIsLoading(false);
       }
     };
 
     fetchData();
-  }, [quantity, unit]);
+  }, [timeframeType, customPeriod]);
 
   // Update chart data when activeChart changes
   React.useEffect(() => {
     if (activeChart === 'donations') {
       setChartData(donationsData);
     } else {
-      setChartData(recurringDonorsData);
+      setChartData(recurringDonationsData);
     }
-  }, [activeChart, donationsData, recurringDonorsData]);
-
-  // Calculate totals for display
-  const donationsTotal = React.useMemo(() => {
-    return donationsData.reduce((acc, curr) => acc + curr.value, 0);
-  }, [donationsData]);
-
-  const recurringDonorsTotal = React.useMemo(() => {
-    return recurringDonorsData.reduce((acc, curr) => acc + curr.value, 0);
-  }, [recurringDonorsData]);
-
-  const handleQuantityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value);
-    if (value >= 1 && value <= 12) {
-      setQuantity(value);
-    }
-  };
+  }, [activeChart, donationsData, recurringDonationsData]);
 
   return (
-    <Card className="py-4 sm:py-0">
-      <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row">
-        <div className="flex flex-1 flex-col justify-center gap-1 px-6 pb-3 sm:pb-0">
-          <CardTitle>Donor Statistics</CardTitle>
+    <Card className="m-3 py-4 sm:py-0 !ring-slate-300">
+      <CardHeader className="flex flex-col items-stretch border-b !p-0 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-1 flex-col justify-center gap-1 px-6 pb-4 sm:pb-0 my-2">
+          <CardTitle className="text-xl font-semibold">
+            Donation Overview
+          </CardTitle>
           <CardDescription>
-            {activeChart === 'donations'
-              ? 'Total donation amounts over time'
-              : 'New recurring donors over time'}
+            Showing total and recurring donations.
           </CardDescription>
         </div>
-        <div className="flex">
-          {(['donations', 'recurring_donors'] as const).map((key) => {
-            const chart = key as DataType;
-            return (
+        <Popover open={customPickerOpen} onOpenChange={setCustomPickerOpen}>
+          <div className="px-6">
+            <div className="inline-flex border border-gray-300 rounded-lg overflow-hidden">
               <button
-                key={String(chart)}
-                data-active={activeChart === chart}
-                className="data-[active=true]:bg-muted/50 flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left even:border-l sm:border-t-0 sm:border-l sm:px-8 sm:py-6"
-                onClick={() => setActiveChart(chart)}
+                data-active={timeframeType === 'year-to-date'}
+                className="data-[active=true]:bg-gray-200 data-[active=false]:hover:bg-muted/50 px-4 py-2 text-sm font-medium transition-colors border-r border-gray-300"
+                onClick={() => setTimeframeType('year-to-date')}
               >
-                <span className="text-muted-foreground text-xs">
-                  {chartConfig[chart].label}
-                </span>
-                <span className="text-lg leading-none font-bold sm:text-3xl">
-                  {isLoading
-                    ? '...'
-                    : chart === 'donations'
-                      ? `$${(donationsTotal / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                      : recurringDonorsTotal.toLocaleString()}
-                </span>
+                Year-to-date
               </button>
-            );
-          })}
-        </div>
+              <PopoverTrigger asChild>
+                <button
+                  data-active={customPickerOpen || timeframeType === 'custom'}
+                  className="data-[active=true]:bg-gray-200 data-[active=false]:hover:bg-muted/50 px-4 py-2 text-sm font-medium transition-colors flex items-center gap-1"
+                >
+                  Custom
+                  <ChevronDownIcon className="h-4 w-4" />
+                </button>
+              </PopoverTrigger>
+            </div>
+          </div>
+          <PopoverContent className="w-auto p-0" align="end">
+            <YearMonthPickerPanel
+              value={customPeriod}
+              onChange={(v) => {
+                setCustomPeriod(v);
+                setTimeframeType('custom');
+                setCustomPickerOpen(false);
+              }}
+            />
+          </PopoverContent>
+        </Popover>
       </CardHeader>
       <CardContent className="px-2 sm:p-6">
         <ChartContainer
           config={chartConfig}
           className="aspect-auto h-[250px] w-full"
         >
-          <LineChart
+          <AreaChart
             accessibilityLayer
             data={chartData}
             margin={{
@@ -288,19 +293,14 @@ export function DonorStatsChart() {
               axisLine={false}
               tickMargin={8}
               tickFormatter={(value) => {
-                if (activeChart === 'donations') {
-                  // Format as currency (e.g., $50)
-                  return `$${(value / 100).toLocaleString()}`;
-                } else {
-                  // Format as count (e.g., 4)
-                  return value.toString();
-                }
+                // Format as currency for both donations and recurring donations
+                return `$${(value / 100).toLocaleString()}`;
               }}
             />
             <ChartTooltip
               content={
                 <ChartTooltipContent
-                  className="w-[150px]"
+                  className="w-[150px] bg-white"
                   nameKey="value"
                   labelFormatter={(value: string) => {
                     return parseDateKey(value).toLocaleDateString('en-US', {
@@ -310,77 +310,52 @@ export function DonorStatsChart() {
                     });
                   }}
                   formatter={(value: any) => {
-                    if (activeChart === 'donations') {
-                      // Format as currency with cents
-                      return `$${(value / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-                    } else {
-                      // Format as count
-                      return value.toLocaleString();
-                    }
+                    // Format as currency for both donations and recurring donations
+                    return `$${(value / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
                   }}
                 />
               }
             />
-            <Line
+            <Area
               dataKey="value"
               type="monotone"
+              fill={chartConfig[activeChart].color}
               stroke={chartConfig[activeChart].color}
               strokeWidth={2}
-              dot={{
-                fill: chartConfig[activeChart].color,
-                r: 4,
-              }}
-              activeDot={{
-                r: 6,
-              }}
+              dot={false}
+              isAnimationActive={false}
             />
-          </LineChart>
+          </AreaChart>
         </ChartContainer>
+
+        <div className="mt-6 flex justify-center">
+          <div className="inline-flex border border-gray-300 rounded-lg overflow-hidden">
+            {(['donations', 'recurring_donations'] as const).map(
+              (key, index) => {
+                const chart = key as DataType;
+                return (
+                  <button
+                    key={String(chart)}
+                    data-active={activeChart === chart}
+                    className="data-[active=true]:bg-gray-200 data-[active=false]:hover:bg-muted/50 px-4 py-2 text-sm font-medium transition-colors"
+                    style={{
+                      borderRight: index === 0 ? '1px solid #d1d5db' : 'none',
+                    }}
+                    onClick={() => setActiveChart(chart)}
+                  >
+                    {chartConfig[chart].label}
+                  </button>
+                );
+              },
+            )}
+          </div>
+        </div>
 
         {error && (
           <div className="mt-4 text-sm text-destructive text-center">
             {error}
           </div>
         )}
-
-        <div className="mt-6 flex items-end gap-4 border-t pt-4">
-          <div className="flex-1">
-            <Label htmlFor="quantity">Time Frame</Label>
-            <div className="flex gap-2 mt-1.5">
-              <Input
-                id="quantity"
-                type="number"
-                min="1"
-                max="12"
-                value={quantity}
-                onChange={handleQuantityChange}
-                className="w-20"
-              />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button className="flex h-10 w-[140px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-                    {unit.charAt(0).toUpperCase() + unit.slice(1)}
-                    <ChevronDownIcon className="ml-2 h-4 w-4" />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  <DropdownMenuItem onSelect={() => setUnit('weeks')}>
-                    Weeks
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setUnit('months')}>
-                    Months
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => setUnit('years')}>
-                    Years
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-          <div className="text-sm text-muted-foreground">
-            Showing last {quantity} {unit}
-          </div>
-        </div>
       </CardContent>
     </Card>
   );

--- a/apps/frontend/src/components/YearMonthPicker.tsx
+++ b/apps/frontend/src/components/YearMonthPicker.tsx
@@ -1,0 +1,254 @@
+import * as React from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import { Button } from '@components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@components/ui/popover';
+import { cn } from '@lib/utils';
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+export type YearMonthValue =
+  | { year: number; month: null }
+  | { year: number; month: number }; // month is 1-indexed
+
+interface YearMonthPickerProps {
+  value?: YearMonthValue;
+  onChange?: (value: YearMonthValue) => void;
+  placeholder?: string;
+}
+
+function formatValue(value?: YearMonthValue): string {
+  if (!value) return '';
+  if (value.month === null) return String(value.year);
+  return `${MONTHS[value.month - 1]} ${value.year}`;
+}
+
+export function YearMonthPicker({
+  value,
+  onChange,
+  placeholder = 'Select period',
+}: YearMonthPickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            'w-[160px] justify-start text-left font-normal',
+            !value && 'text-muted-foreground',
+          )}
+        >
+          {value ? formatValue(value) : placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <YearMonthPickerPanel
+          value={value}
+          onChange={(v) => {
+            onChange?.(v);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface YearMonthPickerPanelProps {
+  value?: YearMonthValue;
+  onChange?: (value: YearMonthValue) => void;
+}
+
+export function YearMonthPickerPanel({
+  value,
+  onChange,
+}: YearMonthPickerPanelProps) {
+  const now = new Date();
+  const curYear = now.getFullYear();
+  const curMonth = now.getMonth(); // 0-indexed
+
+  const [view, setView] = React.useState<'year' | 'month'>('year');
+  // Start the range so current year is bottom-right (position 11 in a 12-item grid)
+  const [rangeStart, setRangeStart] = React.useState(() => curYear - 11);
+  const [selectedYear, setSelectedYear] = React.useState<number | null>(
+    value?.year ?? null,
+  );
+  const [selectedMonth, setSelectedMonth] = React.useState<number | null>(
+    value?.month != null ? value.month - 1 : null, // store 0-indexed internally
+  );
+
+  const years = Array.from({ length: 12 }, (_, i) => rangeStart + i);
+  const canNextRange = rangeStart + 12 <= curYear;
+
+  function handleApply() {
+    if (selectedYear === null) return;
+    if (view === 'year') {
+      onChange?.({ year: selectedYear, month: null });
+    } else {
+      if (selectedMonth === null) return;
+      onChange?.({ year: selectedYear, month: selectedMonth + 1 });
+    }
+  }
+
+  function handlePrev() {
+    if (view === 'year') {
+      setRangeStart((r) => r - 12);
+    } else {
+      setSelectedYear((y) => (y !== null ? y - 1 : y));
+      setSelectedMonth(null);
+    }
+  }
+
+  function handleNext() {
+    if (view === 'year') {
+      if (canNextRange) setRangeStart((r) => r + 12);
+    } else {
+      if (selectedYear !== null && selectedYear < curYear) {
+        setSelectedYear(selectedYear + 1);
+        setSelectedMonth(null);
+      }
+    }
+  }
+
+  const canApply =
+    selectedYear !== null && (view === 'year' || selectedMonth !== null);
+
+  const headerLabel =
+    view === 'year'
+      ? `${years[0]}–${years[years.length - 1]}`
+      : String(selectedYear);
+
+  const nextDisabled =
+    view === 'year'
+      ? !canNextRange
+      : selectedYear === null || selectedYear >= curYear;
+
+  return (
+    <div className="p-4 w-[280px] bg-white rounded-md shadow-md">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={handlePrev}
+          className="flex items-center justify-center w-8 h-8 rounded-md border border-input bg-background hover:bg-muted transition-colors"
+        >
+          <ChevronLeftIcon className="h-4 w-4" />
+        </button>
+        <span className="text-sm font-medium">{headerLabel}</span>
+        <button
+          onClick={handleNext}
+          disabled={nextDisabled}
+          className={cn(
+            'flex items-center justify-center w-8 h-8 rounded-md border border-input bg-background hover:bg-muted transition-colors',
+            nextDisabled && 'opacity-30 cursor-not-allowed pointer-events-none',
+          )}
+        >
+          <ChevronRightIcon className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Grid */}
+      {view === 'year' ? (
+        <div className="grid grid-cols-3 gap-2 mb-4">
+          {years.map((y) => {
+            const isFuture = y > curYear;
+            const isSelected = y === selectedYear;
+            return (
+              <button
+                key={y}
+                disabled={isFuture}
+                onClick={() => setSelectedYear(y)}
+                className={cn(
+                  'py-2 text-sm rounded-md border transition-colors',
+                  isSelected
+                    ? 'bg-[#007B64] text-white border-[#007B64]'
+                    : isFuture
+                      ? 'text-muted-foreground border-border opacity-40 cursor-not-allowed'
+                      : 'border-border hover:bg-muted',
+                )}
+              >
+                {y}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-2 mb-4">
+          {MONTHS.map((m, i) => {
+            const isFuture = selectedYear === curYear && i > curMonth;
+            const isSelected = i === selectedMonth;
+            return (
+              <button
+                key={m}
+                disabled={isFuture}
+                onClick={() => setSelectedMonth(i)}
+                className={cn(
+                  'py-2 text-sm rounded-md border transition-colors',
+                  isSelected
+                    ? 'bg-[#007B64] text-white border-[#007B64]'
+                    : isFuture
+                      ? 'text-muted-foreground border-border opacity-40 cursor-not-allowed'
+                      : 'border-border hover:bg-muted',
+                )}
+              >
+                {m}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="flex flex-col gap-2">
+        {view === 'year' && (
+          <button
+            disabled={selectedYear === null}
+            onClick={() => {
+              if (selectedYear !== null) {
+                setView('month');
+                setSelectedMonth(null);
+              }
+            }}
+            className={cn(
+              'w-full py-2.5 text-sm rounded-md border border-input bg-background transition-colors',
+              selectedYear !== null
+                ? 'hover:bg-muted cursor-pointer'
+                : 'opacity-40 cursor-not-allowed',
+            )}
+          >
+            Select Month →
+          </button>
+        )}
+        <button
+          disabled={!canApply}
+          onClick={handleApply}
+          className={cn(
+            'w-full py-2.5 text-sm font-medium rounded-md border transition-colors',
+            canApply
+              ? 'bg-[#007B64] border-[#007B64] text-white hover:bg-[#005a4d] cursor-pointer'
+              : 'bg-muted text-muted-foreground border-border opacity-40 cursor-not-allowed',
+          )}
+        >
+          Apply Dates
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/YearMonthPicker.tsx
+++ b/apps/frontend/src/components/YearMonthPicker.tsx
@@ -86,7 +86,6 @@ export function YearMonthPickerPanel({
   const curMonth = now.getMonth(); // 0-indexed
 
   const [view, setView] = React.useState<'year' | 'month'>('year');
-  // Start the range so current year is bottom-right (position 11 in a 12-item grid)
   const [rangeStart, setRangeStart] = React.useState(() => curYear - 11);
   const [selectedYear, setSelectedYear] = React.useState<number | null>(
     value?.year ?? null,
@@ -143,7 +142,6 @@ export function YearMonthPickerPanel({
 
   return (
     <div className="p-4 w-[280px] bg-white rounded-md shadow-md">
-      {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={handlePrev}
@@ -164,7 +162,6 @@ export function YearMonthPickerPanel({
         </button>
       </div>
 
-      {/* Grid */}
       {view === 'year' ? (
         <div className="grid grid-cols-3 gap-2 mb-4">
           {years.map((y) => {
@@ -215,7 +212,6 @@ export function YearMonthPickerPanel({
         </div>
       )}
 
-      {/* Footer */}
       <div className="flex flex-col gap-2">
         {view === 'year' && (
           <button

--- a/apps/frontend/src/components/ui/popover.tsx
+++ b/apps/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '@lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@nestjs/swagger": "^7.1.12",
     "@nestjs/typeorm": "^10.0.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-primitive": "^2.1.4",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,6 +4473,27 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-popover@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"
+  integrity sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-focus-guards" "1.1.3"
+    "@radix-ui/react-focus-scope" "1.1.7"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
 "@radix-ui/react-popper@1.2.8":
   version "1.2.8"
   resolved "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz"


### PR DESCRIPTION
## Description

Updated DonorStatsChart to match figma.
Updated /api/donations/stats endpoint to also take in optional start and end date so that the chart can use this endpoint to get the corresponding donation data
Added a YearMonthPicker component for the custom date picker for the stats chart
Added popover shadcn component

## Changes Made

- [ ] Backend changes
- [x] Frontend changes
- [ ] Database schema changes
- [ ] Configuration updates
- [ ] Other

## Testing & Verification

- [x] Unit tests pass
- [x] Manual testing completed
- [x] No breaking changes

**Verification Steps:**

On /chart page:
<img width="2484" height="622" alt="image" src="https://github.com/user-attachments/assets/17edbf6c-a60a-4140-954c-3b517bc94846" />
<img width="2487" height="631" alt="image" src="https://github.com/user-attachments/assets/b4e0f975-8107-462e-90b3-2d600baf63d7" />
Selecting a specific month:
<img width="449" height="598" alt="image" src="https://github.com/user-attachments/assets/7433d4a7-89a7-4497-adfc-c4130873e54e" />
<img width="443" height="522" alt="image" src="https://github.com/user-attachments/assets/25c6c50b-e5f2-49e9-9622-1a985d13af51" />
Only the data for that specific month is displayed:
<img width="2490" height="629" alt="image" src="https://github.com/user-attachments/assets/09b072fc-91bd-456d-8c6f-fd73eb8998fb" />

## Related Issues

Closes #98 
