### PR TITLE
feat: email signature

### DIFF
--- a/apps/frontend/src/components/EmailComms/EmailEditorOverviewPage.tsx
+++ b/apps/frontend/src/components/EmailComms/EmailEditorOverviewPage.tsx
@@ -25,6 +25,7 @@ export function EmailEditor() {
       try {
         const templates = await apiClient.getEmailTemplates();
         if (templates && templates.length > 0) {
+          let loadedMeta = false;
           setEmails((prev) => {
             const next = { ...prev };
             templates.forEach((t: any) => {
@@ -34,10 +35,33 @@ export function EmailEditor() {
               else if (t.type === 'email_subscribers') tab = 'mass';
 
               if (tab) {
+                const bodyMatch = t.bodyHtml.match(
+                  /<!-- FCC_BODY_START -->([\s\S]*?)<!-- FCC_BODY_END -->/,
+                );
+                const body = bodyMatch ? bodyMatch[1].trim() : t.bodyHtml;
+
                 next[tab] = {
                   subject: t.subject,
-                  body: t.bodyHtml,
+                  body: body,
                 };
+              }
+
+              if (!loadedMeta) {
+                const metaMatch = t.bodyHtml.match(/<!-- FCC_META:(.*?) -->/);
+                if (metaMatch) {
+                  try {
+                    const meta = JSON.parse(metaMatch[1]);
+                    if (meta.sig) setSig(meta.sig);
+                    if (meta.ctaText) setCtaText(meta.ctaText);
+                    if (meta.ctaLink) setCtaLink(meta.ctaLink);
+                    loadedMeta = true; // Use the first found metadata
+                  } catch (e) {
+                    console.error(
+                      'Failed to parse metadata from email template',
+                      e,
+                    );
+                  }
+                }
               }
             });
             return next;
@@ -60,13 +84,15 @@ export function EmailEditor() {
 
   const buildFullHTML = () => {
     const email = emails[activeTab];
-    return `
-      <html><body>
-        ${email.body}
-        ${buildSignatureHTML(sig)}
-        ${ctaText ? `<div style="text-align:center;margin:28px 0"><a href="${ctaLink}" style="background:#059669;color:white;padding:14px 32px;border-radius:8px;font-weight:700;text-decoration:none;font-size:14px;letter-spacing:0.05em">${ctaText}</a></div>` : ''}
-      </body></html>
-    `;
+    const metadata = { sig, ctaText, ctaLink };
+    return `<!-- FCC_META:${JSON.stringify(metadata)} -->
+<html><body>
+  <!-- FCC_BODY_START -->
+  ${email.body}
+  <!-- FCC_BODY_END -->
+  ${buildSignatureHTML(sig)}
+  ${ctaText ? `<div style="text-align:center;margin:28px 0"><a href="${ctaLink}" style="background:#059669;color:white;padding:14px 32px;border-radius:8px;font-weight:700;text-decoration:none;font-size:14px;letter-spacing:0.05em">${ctaText}</a></div>` : ''}
+</body></html>`;
   };
 
   const handleSave = async () => {

--- a/apps/frontend/src/components/EmailComms/SignatureEditorCard.tsx
+++ b/apps/frontend/src/components/EmailComms/SignatureEditorCard.tsx
@@ -25,11 +25,27 @@ export default function SignatureEditor({
     <div className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-3">
         {field('Full Name', 'name', 'Your name')}
-
         {field('Position', 'position', 'Your title')}
-
-        {field('Email', 'email', 'you@company.com')}
+        {field('Email', 'email', 'mallory@fenwaycommunitycenter.org')}
+        {field('Pronouns', 'pronouns', '(she/her)')}
+        {field('Website', 'website', 'https://fenwaycommunitycenter.org/')}
+        {field(
+          'LinkedIn',
+          'linkedin',
+          'https://www.linkedin.com/company/fenwaycommunitycenter',
+        )}
+        {field('X (Twitter)', 'X', 'https://twitter.com/...')}
+        {field(
+          'Facebook',
+          'facebook',
+          'https://www.facebook.com/fenwaycommunitycenter',
+        )}
       </div>
+      {field(
+        'Image Upload (CDN URL placeholder)',
+        'imageUrl',
+        'https://example.com/image.png',
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/EmailComms/types.ts
+++ b/apps/frontend/src/components/EmailComms/types.ts
@@ -11,6 +11,7 @@ export type Signature = {
   linkedin: string;
   X: string;
   facebook: string;
+  imageUrl: string;
 };
 
 export type EmailData = {
@@ -61,12 +62,13 @@ export const defaultEmails: EmailsState = {
 export const DEFAULT_SIGNATURE: Signature = {
   name: 'Mallory Rohig',
   position: 'Executive Director',
-  email: 'filler-email@gmail.com',
+  email: 'mallory@fenwaycommunitycenter.org',
   pronouns: '(she/her)',
   website: 'https://fenwaycommunitycenter.org/',
-  linkedin: 'https://www.linkedin.com/company/fenwaycommunitycenter/',
-  X: 'https://fenwaycommunitycenter.org/?share=x&nb=1',
-  facebook: 'https://fenwaycommunitycenter.org/?share=facebook&nb=1',
+  linkedin: 'https://www.linkedin.com/company/fenwaycommunitycenter',
+  X: '',
+  facebook: 'https://www.facebook.com/fenwaycommunitycenter',
+  imageUrl: '',
 };
 
 export const TAB_CONFIG: { id: TabId; label: string }[] = [
@@ -94,12 +96,14 @@ export function buildSignatureHTML(sig: Signature): string {
       : '',
   ].join('');
 
+  const imageSrc = sig.imageUrl ? sig.imageUrl : FCCEmailMallory;
+
   return `
     <table cellpadding="0" cellspacing="0" border="0" style="width:100%;font-family:Arial,sans-serif;max-width:100%;table-layout:fixed;">
       <tr>
         <!-- Photo -->
         <td style="vertical-align:middle;width:clamp(45px, 6vw, 65px);padding-right:clamp(6px, 1vw, 12px);">
-          <img src="${FCCEmailMallory}" alt="${sig.name}"
+          <img src="${imageSrc}" alt="${sig.name}"
             style="width:clamp(40px, 5vw, 60px);height:clamp(40px, 5vw, 60px);border-radius:50%;object-fit:cover;object-position:top;border:2px solid white;display:block;" />
         </td>
 
@@ -112,6 +116,13 @@ export function buildSignatureHTML(sig: Signature): string {
 
         <!-- Website + Social -->
         <td style="vertical-align:middle;text-align:right;width:35%;min-width:100px;">
+          ${
+            sig.email
+              ? `<p style="margin:0 0 2px;font-size:clamp(9px, 1.2vw, 12px);font-weight:700;color:#1a1a1a;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+            <a href="mailto:${sig.email}" target="_blank" rel="noreferrer" style="color:#1a1a1a;text-decoration:none;">${sig.email}</a>
+          </p>`
+              : ''
+          }
           ${
             sig.website
               ? `<p style="margin:0 0 6px;font-size:clamp(9px, 1.2vw, 12px);font-weight:700;color:#1a1a1a;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">


### PR DESCRIPTION
## Description
Wired up the frontend Email Editor to the backend template endpoints and fixed the signature/CTA state loading.

## Changes Made
- [x] Frontend changes
- Added template fetching on mount for all 3 email types.
- Fixed the duplicating signature bug on reload by wrapping metadata in hidden HTML comments to safely parse out the body text.
- Added all missing signature inputs (Name, Email, Pronouns, Socials, etc.) and updated defaults to the official FCC links.

## Testing & Verification
- [x] Manual testing completed
- [x] Lint passes

## Future Improvements/Notes
- Left a placeholder text input for the signature image URL for now. I'm waiting on the S3/CDN feature from Hannah's ticket before swapping this to a real input. 

## Related Issues
Closes #114 