### PR TITLE
130 fix dono goal in dono page to reflect real goal remove placeholder

### DIFF
--- a/apps/backend/src/donations/goal.entity.ts
+++ b/apps/backend/src/donations/goal.entity.ts
@@ -13,7 +13,7 @@ export class Goal {
   })
   id!: number;
 
-  @Column({ type: 'int' })
+  @Column({ name: 'admin_target_amount', type: 'int' })
   targetAmount!: number;
 
   @Column({ type: 'text', nullable: true })

--- a/apps/backend/src/migrations/1781161660-rename-goal-columns.ts
+++ b/apps/backend/src/migrations/1781161660-rename-goal-columns.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameGoalColumns1781161660 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "goals" RENAME COLUMN "targetAmount" TO "admin_target_amount"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "goals" RENAME COLUMN "admin_target_amount" TO "targetAmount"`,
+    );
+  }
+}

--- a/apps/frontend/src/components/DonationGoal/EditDonationGoal.tsx
+++ b/apps/frontend/src/components/DonationGoal/EditDonationGoal.tsx
@@ -53,11 +53,11 @@ export default function EditDonationGoal({
 
   return (
     <div
-      className="flex aspect-[7/10] w-full flex-col gap-3 rounded-[10px] border border-[#E5E5E5] bg-[#FCFCFC] p-4 font-['Source_Sans_Pro'] shadow-[0px_4px_12px_rgba(0,0,0,0.1)]"
+      className="flex h-full w-full flex-col gap-3 overflow-y-auto rounded-[10px] border border-[#E5E5E5] bg-[#FCFCFC] p-4 font-['Source_Sans_Pro'] shadow-[0px_4px_12px_rgba(0,0,0,0.1)]"
       onClick={(e) => e.stopPropagation()}
     >
       {/* Header */}
-      <div className="mb-1 flex w-full items-start justify-between border-b border-[#E5E5E5] pb-2">
+      <div className="mb-1 flex w-full shrink-0 items-start justify-between border-b border-[#E5E5E5] pb-2">
         <h4 className="text-[18px] font-semibold leading-tight tracking-[-0.2px] text-black">
           Edit Donation Goal
         </h4>
@@ -72,7 +72,7 @@ export default function EditDonationGoal({
       </div>
 
       {/* Title Field */}
-      <div className="flex w-full flex-col gap-1">
+      <div className="flex w-full shrink-0 flex-col gap-1">
         <label className="text-[13px] font-normal leading-tight text-[#171717]">
           Title displayed on{' '}
           <span className="font-bold">live donation site</span>
@@ -90,7 +90,7 @@ export default function EditDonationGoal({
       </div>
 
       {/* Goal Amount Field */}
-      <div className="flex w-full flex-col gap-1">
+      <div className="flex w-full shrink-0 flex-col gap-1">
         <div className="flex w-full items-center justify-between">
           <label className="text-[13px] font-normal leading-tight text-[#171717]">
             Goal Amount
@@ -115,7 +115,7 @@ export default function EditDonationGoal({
       </div>
 
       {/* Start Date Field */}
-      <div className="flex w-full flex-col gap-1">
+      <div className="flex w-full shrink-0 flex-col gap-1">
         <label className="text-[13px] font-normal leading-tight text-[#171717]">
           Start Date
         </label>
@@ -136,7 +136,7 @@ export default function EditDonationGoal({
       </div>
 
       {/* End Date Field */}
-      <div className="flex w-full flex-col gap-1">
+      <div className="flex w-full shrink-0 flex-col gap-1">
         <label className="text-[13px] font-normal leading-tight text-[#171717]">
           End Date
         </label>
@@ -159,7 +159,7 @@ export default function EditDonationGoal({
       <div className="flex-grow" />
 
       {/* Bottom Buttons */}
-      <div className="flex w-full gap-2">
+      <div className="mt-auto flex w-full shrink-0 gap-2 pt-2">
         <button
           type="button"
           onClick={onCancel}

--- a/apps/frontend/src/containers/dashboard/sidebar/Sidebar.tsx
+++ b/apps/frontend/src/containers/dashboard/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '../../../components/AuthProvider';
 import {
   Bookmark,
   ListFilter,
@@ -58,6 +59,16 @@ type SidebarProps = {
 
 export default function Sidebar({ className }: SidebarProps) {
   const { pathname } = useLocation();
+  const { user } = useAuth();
+
+  const isAdmin = user?.status === 'ADMIN';
+
+  const filteredNavItems = navItems.filter((item) => {
+    if (item.href === '/dashboard/approval') {
+      return isAdmin;
+    }
+    return true;
+  });
 
   return (
     <aside
@@ -76,7 +87,7 @@ export default function Sidebar({ className }: SidebarProps) {
       </div>
 
       <nav className="flex w-full flex-col gap-0.05 px-4 pt-8">
-        {navItems.map((item) => {
+        {filteredNavItems.map((item) => {
           const isActive = pathname === item.href;
 
           return (


### PR DESCRIPTION
## Description

- Fixed Edit Donation Goal panel overflow and visibility by removing strict aspect ratios and adding internal scrolling.
- Implemented role-based visibility for the Admin Approval tab in the dashboard sidebar, restricting it to `ADMIN` users.
- Identified and addressed a data sync issue between Amplify (Admin) and WordPress (User-facing) caused by hardcoded fallbacks and API URL configuration.
- Renamed the internal database column to `admin_target_amount` via migration to clearly distinguish the admin-controlled goal from other goal types.


Closes #130 
